### PR TITLE
Revert "Update dependency com.google.devtools.ksp to v1.9.21-1.0.15"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ jetbrains-annotation = "24.1.0"
 
 kotlin-core = "1.9.20"
 kotlin-coroutines = "1.7.3"
-kotlin-ksp = "1.9.21-1.0.15"
+kotlin-ksp = "1.9.20-1.0.14"
 kotlin-kotlinpoet = "1.15.2"
 kotlin-ktlint-gradle = "11.6.1"
 kotlin-ktlint-source = "0.48.2"


### PR DESCRIPTION
Reverts jisungbin/ComposeInvestigator#47.

KSP version should tracked by https://github.com/jisungbin/ComposeInvestigator/pull/53.