### PR TITLE
Fix some bugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
   alias(libs.plugins.test.gradle.logging) apply false
+  alias(libs.plugins.gradle.publish.maven) apply false
   alias(libs.plugins.kotlin.ktlint) apply false
 }
 

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/IrBugChecks.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/IrBugChecks.kt
@@ -17,18 +17,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 
-//@Composable
-//fun () {
-//  var state1 by remember { mutableStateOf("Unit") }
-//  Text(text = state1)
-//
-//  Surface {
-//    val state2 = remember { mutableStateOf("Unit") }
-//    Text(text = state2.value)
-//
-//    Surface {
-//      val state3 by remember { mutableStateOf("Unit") }
-//      Text(text = state3)
-//    }
-//  }
-//}
+@Composable
+fun NestedLocalStateCapture() {
+  var state1 by remember { mutableStateOf("Unit") }
+  Text(text = state1)
+
+  Surface {
+    val state2 = remember { mutableStateOf("Unit") }
+    Text(text = state2.value)
+
+    Surface {
+      val state3 by remember { mutableStateOf("Unit") }
+      Text(text = state3)
+    }
+  }
+}

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/IrBugChecks.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/IrBugChecks.kt
@@ -1,0 +1,34 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("UNUSED_VARIABLE", "CanBeVal")
+
+package land.sungbin.composeinvestigator.compiler.test.source.logger
+
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+//@Composable
+//fun () {
+//  var state1 by remember { mutableStateOf("Unit") }
+//  Text(text = state1)
+//
+//  Surface {
+//    val state2 = remember { mutableStateOf("Unit") }
+//    Text(text = state2.value)
+//
+//    Surface {
+//      val state3 by remember { mutableStateOf("Unit") }
+//      Text(text = state3)
+//    }
+//  }
+//}

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/logger.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/logger/logger.kt
@@ -20,6 +20,6 @@ fun clearInvalidationLog() {
 fun findInvalidationLog(composableName: String): List<ComposableInvalidationType> =
   invalidationLog.filterKeys { composable -> composable.name == composableName }.values.flatten()
 
-val invalidationLogger: ComposableInvalidationLogger = ComposableInvalidationLogger { composable, type ->
+val invalidationLogger = ComposableInvalidationLogger { composable, type ->
   invalidationLog.getOrPut(composable, ::mutableListOf).add(type)
 }

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/invalidationtracktablecall/TableCallFile1.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/invalidationtracktablecall/TableCallFile1.kt
@@ -7,6 +7,7 @@
 
 package land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall
 
+import androidx.compose.runtime.Composable
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import land.sungbin.composeinvestigator.runtime.ComposableName
@@ -19,14 +20,16 @@ fun table1() {
   table1 shouldBeSameInstanceAs currentComposableInvalidationTracker
 }
 
-fun currentComposableName1() {
+@Composable
+fun CurrentComposableName1() {
   val prevComposableName by table1.currentComposableName
-  prevComposableName shouldBe "currentComposableName1"
+  prevComposableName shouldBe "CurrentComposableName1"
 
   table1.currentComposableName = ComposableName("ChangedComposableName1")
   table1.currentComposableName.name shouldBe "ChangedComposableName1"
 }
 
-fun currentComposableKeyName1() {
-  table1.currentComposableKeyName shouldBe "fun-currentComposableKeyName1()Unit/pkg-land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall/file-TableCallFile1.kt"
+@Composable
+fun CurrentComposableKeyName1() {
+  table1.currentComposableKeyName shouldBe "fun-CurrentComposableKeyName1(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall/file-TableCallFile1.kt"
 }

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/invalidationtracktablecall/TableCallFile2.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/invalidationtracktablecall/TableCallFile2.kt
@@ -7,6 +7,7 @@
 
 package land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall
 
+import androidx.compose.runtime.Composable
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import land.sungbin.composeinvestigator.runtime.ComposableName
@@ -19,14 +20,16 @@ fun table2() {
   table2 shouldBeSameInstanceAs currentComposableInvalidationTracker
 }
 
-fun currentComposableName2() {
+@Composable
+fun CurrentComposableName2() {
   val prevComposableName by table2.currentComposableName
-  prevComposableName shouldBe "currentComposableName2"
+  prevComposableName shouldBe "CurrentComposableName2"
 
   table2.currentComposableName = ComposableName("ChangedComposableName2")
   table2.currentComposableName.name shouldBe "ChangedComposableName2"
 }
 
-fun currentComposableKeyName2() {
-  table2.currentComposableKeyName shouldBe "fun-currentComposableKeyName2()Unit/pkg-land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall/file-TableCallFile2.kt"
+@Composable
+fun CurrentComposableKeyName2() {
+  table2.currentComposableKeyName shouldBe "fun-CurrentComposableKeyName2(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall/file-TableCallFile2.kt"
 }

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/source/SourceForIrDump.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/source/SourceForIrDump.kt
@@ -2,8 +2,6 @@
 
 package land.sungbin.composeinvestigator.compiler.test.source
 
-import androidx.compose.material.Button
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -12,19 +10,6 @@ import androidx.compose.runtime.setValue
 
 @Composable
 fun InvalidationProcessedRoot_StateDelegateReference() {
-  var count by remember { mutableIntStateOf(0) }
-  Button(onClick = { count = 1 }) {}
-  InvalidationProcessedChild(count)
-}
-
-@Composable
-fun InvalidationProcessedRoot_StateDirectReference() {
-  val count = remember { mutableIntStateOf(0) }
-  Button(onClick = { count.intValue = 1 }) {}
-  InvalidationProcessedChild(count.intValue)
-}
-
-@Composable
-private fun InvalidationProcessedChild(count: Int) {
-  Text(text = "$count")
+  val countDirect = remember { mutableIntStateOf(0) }
+  var countDelegation by remember { mutableIntStateOf(0) }
 }

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/logger/IrBugCheckTest.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/logger/IrBugCheckTest.kt
@@ -15,16 +15,16 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-//@RunWith(AndroidJUnit4::class)
-//class IrBugCheckTest {
-//  @get:Rule
-//  val compose = createAndroidComposeRule<ComponentActivity>()
-//
-//  @get:Rule
-//  val loggerTest = InvalidationLoggerTestRule()
-//
-//  @Test
-//  fun nested_state() {
-//    compose.setContent { NestedLocalStateCapture() }
-//  }
-//}
+@RunWith(AndroidJUnit4::class)
+class IrBugCheckTest {
+  @get:Rule
+  val compose = createAndroidComposeRule<ComponentActivity>()
+
+  @get:Rule
+  val loggerTest = InvalidationLoggerTestRule()
+
+  @Test
+  fun nested_state() {
+    compose.setContent { NestedLocalStateCapture() }
+  }
+}

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/logger/IrBugCheckTest.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/logger/IrBugCheckTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+package land.sungbin.composeinvestigator.compiler.test.tracker.logger
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import land.sungbin.composeinvestigator.compiler.test.source.logger.NestedLocalStateCapture
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+//@RunWith(AndroidJUnit4::class)
+//class IrBugCheckTest {
+//  @get:Rule
+//  val compose = createAndroidComposeRule<ComponentActivity>()
+//
+//  @get:Rule
+//  val loggerTest = InvalidationLoggerTestRule()
+//
+//  @Test
+//  fun nested_state() {
+//    compose.setContent { NestedLocalStateCapture() }
+//  }
+//}

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/table/InvalidationTrackTableCallTest.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/tracker/table/InvalidationTrackTableCallTest.kt
@@ -13,10 +13,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.matchers.types.shouldNotBeSameInstanceAs
-import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.currentComposableKeyName1
-import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.currentComposableKeyName2
-import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.currentComposableName1
-import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.currentComposableName2
+import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.CurrentComposableKeyName1
+import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.CurrentComposableKeyName2
+import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.CurrentComposableName1
+import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.CurrentComposableName2
 import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.table1
 import land.sungbin.composeinvestigator.compiler.test.source.table.invalidationtracktablecall.table2
 import land.sungbin.composeinvestigator.runtime.ComposableInvalidationTrackTable
@@ -42,13 +42,17 @@ class InvalidationTrackTableCallTest {
 
   @Test
   fun composable_name_change() {
-    currentComposableName1()
-    currentComposableName2()
+    compose.setContent {
+      CurrentComposableName1()
+      CurrentComposableName2()
+    }
   }
 
   @Test
   fun composable_key_name() {
-    currentComposableKeyName1()
-    currentComposableKeyName2()
+    compose.setContent {
+      CurrentComposableKeyName1()
+      CurrentComposableKeyName2()
+    }
   }
 }

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   kotlin("jvm")
-  // alias(libs.plugins.gradle.publish.maven)
   alias(libs.plugins.kotlin.ksp)
+  id(libs.plugins.gradle.publish.maven.get().pluginId)
 }
 
 sourceSets {

--- a/compiler/gradle.properties
+++ b/compiler/gradle.properties
@@ -1,4 +1,4 @@
 POM_NAME=composeinvestigator-compiler
 POM_ARTIFACT_ID=composeinvestigator-compiler
 
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=0.1.1-SNAPSHOT

--- a/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/names.kt
+++ b/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/names.kt
@@ -7,8 +7,10 @@
 
 package land.sungbin.composeinvestigator.compiler.internal
 
+import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 
 // ===== PACKAGE ===== //
 
@@ -27,8 +29,15 @@ internal val TRACE_EVENT_END = Name.identifier("traceEventEnd")
 // ===== FULLY-QUALIFIED NAME ===== //
 
 // START Kotlin Standard Library
+// FIXME: There is a `functionN` factory in `IrBuiltIns`, but it currently produces unbound symbols.
+//        We can switch to this and remove this function once KT-54230 is fixed.
 internal val FUNCTION_2_FQN = FqName("kotlin.jvm.functions.Function2")
 internal val FUNCTION_2_INVOKE_FQN = FUNCTION_2_FQN.child(Name.identifier("invoke"))
+
+internal val MUTABLE_LIST_OF_FQN = FqName("kotlin.collections.mutableListOf")
+internal val MUTABLE_LIST_ADD_FQN = FqName("kotlin.collections.MutableList.add")
+
+internal val HASH_CODE_FQN = FqName("kotlin.hashCode")
 // END Kotlin Standard Library
 
 // START Compose Runtime
@@ -105,3 +114,13 @@ internal val AFFECTED_FIELD_STATE_PROPERTY_FQN = AFFECTED_FIELD_FQN.child(Name.i
 // START affect/AffectedComposable.kt
 internal val AFFECTED_COMPOSABLE_FQN = FqName("$ComposeInvestigatorRuntimeAffect.AffectedComposable")
 // END affect/AffectedComposable.kt
+
+// START helper/IrHelper.kt
+internal val OBTAIN_STATE_PROPERTY_AND_ADD_FQN = FqName("$ComposeInvestigatorRuntime.helper.obtainStatePropertyAndAdd")
+// END helper/IrHelper.kt
+
+public fun CallableId.Companion.fromFqName(fqName: FqName): CallableId =
+  CallableId(packageName = fqName.parent(), callableName = fqName.shortName())
+
+@Suppress("UnusedReceiverParameter")
+public val SpecialNames.UNKNOWN_STRING: String get() = "<unknown>"

--- a/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/key/KeyBindingTrace.kt
+++ b/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/key/KeyBindingTrace.kt
@@ -5,7 +5,7 @@
  * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
  */
 
-// Since this is code copied from the Compose Compiler (AOSP), we use an extra e in the copy to distinguish it.
+// Since this is code copied from the Compose Compiler (AOSP), we use an extra "e" in the copy to distinguish it.
 
 package land.sungbin.composeinvestigator.compiler.internal.tracker.key
 

--- a/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/logger/IrInvalidationLogger.kt
+++ b/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/logger/IrInvalidationLogger.kt
@@ -14,6 +14,7 @@ import land.sungbin.composeinvestigator.compiler.internal.COMPOSE_INVESTIGATOR_C
 import land.sungbin.composeinvestigator.compiler.internal.COMPOSE_INVESTIGATOR_CONFIG_INVALIDATION_LOGGER_FQN
 import land.sungbin.composeinvestigator.compiler.internal.FUNCTION_2_FQN
 import land.sungbin.composeinvestigator.compiler.internal.FUNCTION_2_INVOKE_FQN
+import land.sungbin.composeinvestigator.compiler.internal.fromFqName
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.expressions.IrCall
@@ -48,27 +49,11 @@ public object IrInvalidationLogger {
     loggerContainerSymbol = context.referenceClass(ClassId.topLevel(COMPOSE_INVESTIGATOR_CONFIG_FQN))!!
     loggerGetterSymbol =
       context
-        .referenceProperties(
-          CallableId(
-            packageName = COMPOSE_INVESTIGATOR_CONFIG_INVALIDATION_LOGGER_FQN.parent(),
-            callableName = COMPOSE_INVESTIGATOR_CONFIG_INVALIDATION_LOGGER_FQN.shortName(),
-          ),
-        )
-        .single()
-        .owner
-        .getter!!
-        .symbol
+        .referenceProperties(CallableId.fromFqName(COMPOSE_INVESTIGATOR_CONFIG_INVALIDATION_LOGGER_FQN)).single()
+        .owner.getter!!.symbol
 
     function2Symbol = context.referenceClass(ClassId.topLevel(FUNCTION_2_FQN))!!
-    function2InvokeSymbol =
-      context
-        .referenceFunctions(
-          CallableId(
-            packageName = FUNCTION_2_INVOKE_FQN.parent(),
-            callableName = FUNCTION_2_INVOKE_FQN.shortName(),
-          )
-        )
-        .single()
+    function2InvokeSymbol = context.referenceFunctions(CallableId.fromFqName(FUNCTION_2_INVOKE_FQN)).single()
 
     invalidationTypeSymbol = context.referenceClass(ClassId.topLevel(COMPOSABLE_INVALIDATION_TYPE_FQN))!!
     invalidationTypeProcessedSymbol = context.referenceClass(ClassId.topLevel(COMPOSABLE_INVALIDATION_TYPE_PROCESSED_FQN))!!

--- a/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/table/IrInvalidationTrackTable.kt
+++ b/compiler/src/main/kotlin/land/sungbin/composeinvestigator/compiler/internal/tracker/table/IrInvalidationTrackTable.kt
@@ -10,6 +10,7 @@ package land.sungbin.composeinvestigator.compiler.internal.tracker.table
 import land.sungbin.composeinvestigator.compiler.internal.COMPOSABLE_INVALIDATION_TRACK_TABLE_CALL_LISTENERS_FQN
 import land.sungbin.composeinvestigator.compiler.internal.COMPOSABLE_INVALIDATION_TRACK_TABLE_COMPUTE_INVALIDATION_REASON_FQN
 import land.sungbin.composeinvestigator.compiler.internal.COMPOSABLE_INVALIDATION_TRACK_TABLE_FQN
+import land.sungbin.composeinvestigator.compiler.internal.fromFqName
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -26,7 +27,7 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrDeclarationReference
-import org.jetbrains.kotlin.ir.expressions.IrVararg
+import org.jetbrains.kotlin.ir.expressions.IrValueAccessExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
@@ -62,7 +63,7 @@ public class IrInvalidationTrackTable private constructor(public val prop: IrPro
 
   public fun irComputeInvalidationReason(
     composableKeyName: IrConst<String>,
-    fields: IrVararg,
+    fields: IrValueAccessExpression,
   ): IrCall = IrCallImpl.fromSymbolOwner(
     startOffset = UNDEFINED_OFFSET,
     endOffset = UNDEFINED_OFFSET,
@@ -80,21 +81,11 @@ public class IrInvalidationTrackTable private constructor(public val prop: IrPro
         .also { clz ->
           clz.computeInvalidationReasonSymbol =
             context
-              .referenceFunctions(
-                CallableId(
-                  packageName = COMPOSABLE_INVALIDATION_TRACK_TABLE_COMPUTE_INVALIDATION_REASON_FQN.parent(),
-                  callableName = COMPOSABLE_INVALIDATION_TRACK_TABLE_COMPUTE_INVALIDATION_REASON_FQN.shortName(),
-                ),
-              )
+              .referenceFunctions(CallableId.fromFqName(COMPOSABLE_INVALIDATION_TRACK_TABLE_COMPUTE_INVALIDATION_REASON_FQN))
               .single()
           clz.callListenersSymbol =
             context
-              .referenceFunctions(
-                CallableId(
-                  packageName = COMPOSABLE_INVALIDATION_TRACK_TABLE_CALL_LISTENERS_FQN.parent(),
-                  callableName = COMPOSABLE_INVALIDATION_TRACK_TABLE_CALL_LISTENERS_FQN.shortName(),
-                ),
-              )
+              .referenceFunctions(CallableId.fromFqName(COMPOSABLE_INVALIDATION_TRACK_TABLE_CALL_LISTENERS_FQN))
               .single()
         }
   }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   id("com.android.library")
   kotlin("android")
-  // alias(libs.plugins.gradle.publish.maven)
+  id(libs.plugins.gradle.publish.maven.get().pluginId)
 }
 
 android {

--- a/runtime/gradle.properties
+++ b/runtime/gradle.properties
@@ -1,4 +1,4 @@
 POM_NAME=composeinvestigator-runtime
 POM_ARTIFACT_ID=composeinvestigator-runtime
 
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=0.1.1-SNAPSHOT

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationLogger.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationLogger.kt
@@ -86,7 +86,7 @@ public sealed interface InvalidationReason {
   public data class Unknown(public val params: List<SimpleParameter> = emptyList()) : InvalidationReason {
     override fun toString(): String = "Didn't find any fields that are changed from before. " +
       "Please refer to the project README for more information on why this happens." +
-      if (params.isNotEmpty()) "\n\ngiven parameters: ${params.joinToString()}" else ""
+      if (params.isNotEmpty()) "\ngiven parameters: ${params.joinToString()}" else ""
   }
 }
 

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposeInvestigatorConfig.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposeInvestigatorConfig.kt
@@ -15,6 +15,6 @@ public object ComposeInvestigatorConfig {
 
   public var invalidationLogger: ComposableInvalidationLogger =
     ComposableInvalidationLogger { composable, type ->
-      Log.d(LOGGER_DEFAULT_TAG, "The '${composable.name}' composable has been invalidated.\n\n$type")
+      Log.d(LOGGER_DEFAULT_TAG, "The '${composable.name}' composable has been invalidated.\n$type")
     }
 }

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/helper/IrHelper.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/helper/IrHelper.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by Ji Sungbin 2023.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+package land.sungbin.composeinvestigator.runtime.helper
+
+import androidx.compose.runtime.State
+import land.sungbin.composeinvestigator.runtime.ComposeInvestigatorCompilerApi
+import land.sungbin.composeinvestigator.runtime.affect.AffectedField
+
+// **This function is for the ComposeInvestigator compiler only.** It should be replaced by an IR,
+// but due to the risk and complexity of writing a custom IR, we replace it with a runtime function.
+@ComposeInvestigatorCompilerApi
+public fun <T> State<T>.obtainStatePropertyAndAdd(
+  propertyName: String,
+  destination: MutableList<AffectedField>,
+): State<T> = also { state ->
+  destination.add(
+    AffectedField.StateProperty(
+      name = propertyName,
+      valueString = state.value.toString(),
+      valueHashCode = state.value.hashCode(),
+    ),
+  )
+}

--- a/runtime/src/test/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTableTest.kt
+++ b/runtime/src/test/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTableTest.kt
@@ -24,7 +24,7 @@ class ComposableInvalidationTrackTableTest : FeatureSpec() {
         )
         val invalidationReason = table.computeInvalidationReason(
           keyName = "keyName",
-          fields = arrayOf(param),
+          fields = listOf(param),
         )
 
         table.affectFields shouldBe mapOf("keyName" to listOf(param))
@@ -46,12 +46,12 @@ class ComposableInvalidationTrackTableTest : FeatureSpec() {
         val table = ComposableInvalidationTrackTable().apply {
           computeInvalidationReason(
             keyName = "keyName",
-            fields = arrayOf(oldParam),
+            fields = listOf(oldParam),
           )
         }
         val invalidationReason = table.computeInvalidationReason(
           keyName = "keyName",
-          fields = arrayOf(newParam),
+          fields = listOf(newParam),
         )
 
         table.affectFields shouldBe mapOf("keyName" to listOf(newParam))


### PR DESCRIPTION
This PR contains the following bug fixes:

- The `currentComposable*` API would return values that were not composable
- Collecting `State` from nested local scopes fails to reference the correct value

... and codebase cleaning.