### PR TITLE
Tracking `DerivedState` no longer crashes

### DIFF
--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -1,11 +1,19 @@
 # Change Log
 
-ComposeInvestigator is heavily dependent on the version of [Compose Compiler](https://developer.android.com/jetpack/androidx/releases/compose-compiler),
-so the version of ComposeInvestigator follows the format `[Compose Compiler Version - ComposeInvestigator Version]`.
+ComposeInvestigator is heavily dependent on the version
+of [Compose Compiler](https://developer.android.com/jetpack/androidx/releases/compose-compiler),
+so the version of ComposeInvestigator follows the
+format `[Compose Compiler Version - ComposeInvestigator Version]`.
 
-In other words, you need to adjust the Compose Compiler version and Kotlin version to use ComposeInvestigator.
+In other words, you need to adjust the Compose Compiler version and Kotlin version to use
+ComposeInvestigator.
 
 ---
+
+### Unreleased
+
+- Fixed #123: Tracking `DerivedState` no longer crashes. Instead, due to technical limitations,
+  `DerivedState` is not currently supported for tracking state changes.
 
 ### 1.5.10-0.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ RELEASE_SIGNING_ENABLED=true
 SONATYPE_AUTOMATIC_RELEASE=true
 
 GROUP=land.sungbin.composeinvestigator
-VERSION_NAME=1.5.10-0.1.0
+VERSION_NAME=1.5.10-0.1.1-SNAPSHOT
 
 POM_DESCRIPTION=Trace the recomposition of a Composable with its cause without any boilerplate code.
 POM_INCEPTION_YEAR=2024


### PR DESCRIPTION
Resolves #123.

Tracking `DerivedState` no longer crashes. Instead, due to technical limitations, `DerivedState` is not currently supported for tracking state changes.