### PR TITLE
Eliminated a potential memory leak

### DIFF
--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/ComposableInvalidationTrackingExtension.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/ComposableInvalidationTrackingExtension.kt
@@ -20,20 +20,20 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
 public class ComposableInvalidationTrackingExtension(private val logger: VerboseLogger) : IrGenerationExtension {
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    IrInvalidationLogger.init(pluginContext)
-    IrAffectedField.init(pluginContext)
-    IrAffectedComposable.init(pluginContext)
+    val invalidationLogger = IrInvalidationLogger(pluginContext)
+    val affectedField = IrAffectedField(pluginContext)
+    val affectedComposable = IrAffectedComposable(pluginContext)
 
     val stabilityInferencer = StabilityInferencer(
       currentModule = moduleFragment.descriptor,
-      // TODO: support this field
-      externalStableTypeMatchers = emptySet(),
+      externalStableTypeMatchers = emptySet(), // TODO: support this field
     )
 
     moduleFragment.transformChildrenVoid(
       DurableComposableKeyTransformer(
         context = pluginContext,
         stabilityInferencer = stabilityInferencer,
+        affectedComposable = affectedComposable,
       ),
     )
     moduleFragment.transformChildrenVoid(
@@ -41,6 +41,9 @@ public class ComposableInvalidationTrackingExtension(private val logger: Verbose
         context = pluginContext,
         logger = logger,
         stabilityInferencer = stabilityInferencer,
+        affectedField = affectedField,
+        affectedComposable = affectedComposable,
+        invalidationLogger = invalidationLogger,
       ),
     )
   }

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/ComposeInvestigatorPluginRegistrar.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/ComposeInvestigatorPluginRegistrar.kt
@@ -16,8 +16,8 @@ import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
 public class ComposeInvestigatorPluginRegistrar : ComponentRegistrar {
-  // TODO: Testing
-  override val supportsK2: Boolean = true
+  // TODO: https://github.com/jisungbin/ComposeInvestigator/issues/91
+  override val supportsK2: Boolean = false
 
   // This deprecated override is safe to use up to Kotlin 2.1.0 by KT-55300.
   // Also see: https://youtrack.jetbrains.com/issue/KT-52665/Deprecate-ComponentRegistrar#focus=Change-27-7999959.0-0

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/AbstractComosableInvalidationTrackLower.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/AbstractComosableInvalidationTrackLower.kt
@@ -25,6 +25,7 @@ import land.sungbin.composeinvestigator.compiler.VerboseLogger
 import land.sungbin.composeinvestigator.compiler.fromFqName
 import land.sungbin.composeinvestigator.compiler.origin.ComposableCallstackTrackerSyntheticOrigin
 import land.sungbin.composeinvestigator.compiler.origin.ComposableInvalidationTrackerOrigin
+import land.sungbin.composeinvestigator.compiler.struct.IrAffectedComposable
 import land.sungbin.composeinvestigator.compiler.struct.IrComposableCallstackTracker
 import land.sungbin.composeinvestigator.compiler.struct.IrInvalidationTrackTable
 import land.sungbin.fastlist.fastAny
@@ -85,6 +86,7 @@ public abstract class AbstractComosableInvalidationTrackLower(
   private val context: IrPluginContext,
   private val logger: VerboseLogger,
   private val stabilityInferencer: StabilityInferencer,
+  private val affectedComposable: IrAffectedComposable,
 ) : IrElementTransformerVoidWithContext() {
   private class IrSymbolOwnerWithData<D>(private val owner: IrSymbolOwner, val data: D) : IrSymbolOwner by owner
 
@@ -164,7 +166,12 @@ public abstract class AbstractComosableInvalidationTrackLower(
     }
 
     val table = IrInvalidationTrackTable.create(context, declaration)
-    val tableCallTransformer = InvalidationTrackTableIntrinsicTransformer(context = context, table = table, logger = logger)
+    val tableCallTransformer = InvalidationTrackTableIntrinsicTransformer(
+      context = context,
+      table = table,
+      logger = logger,
+      affectedComposable = affectedComposable,
+    )
     declaration.declarations.add(0, table.prop.also { prop -> prop.setDeclarationsParent(declaration) })
     declaration.transformChildrenVoid(tableCallTransformer)
 

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/DurableComposableKeyTransformer.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/DurableComposableKeyTransformer.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.name.FqName
 public class DurableComposableKeyTransformer(
   context: IrPluginContext,
   stabilityInferencer: StabilityInferencer,
+  private val affectedComposable: IrAffectedComposable,
 ) : DurableKeyTransformer(
   keyVisitor = DurableKeyVisitor(),
   context = context,
@@ -58,7 +59,7 @@ public class DurableComposableKeyTransformer(
     val (keyName) = buildKey("fun-${declaration.signatureString()}")
     val location = declaration.getSafelyLocation()
 
-    val affectedComposable = IrAffectedComposable.irAffectedComposable(
+    val affectedComposable = affectedComposable.irAffectedComposable(
       composableName = irString(declaration.name.asString()),
       packageName = irString((declaration.fqNameWhenAvailable?.parent() ?: FqName.ROOT).asString()),
       filePath = irString(location.file),

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrAffectedComposable.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrAffectedComposable.kt
@@ -12,20 +12,13 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 
-public object IrAffectedComposable {
-  private var affectedComposableSymbol: IrClassSymbol? = null
-
-  public val irAffectedComposable: IrClassSymbol get() = affectedComposableSymbol!!
-
-  public fun init(context: IrPluginContext) {
-    affectedComposableSymbol = context.referenceClass(ClassId.topLevel(AFFECTED_COMPOSABLE_FQN))!!
-  }
+public class IrAffectedComposable(context: IrPluginContext) {
+  private val irAffectedComposable = context.referenceClass(ClassId.topLevel(AFFECTED_COMPOSABLE_FQN))!!
 
   public fun irAffectedComposable(
     composableName: IrConst<String>,
@@ -34,8 +27,8 @@ public object IrAffectedComposable {
     startLine: IrConst<Int>,
     startColumn: IrConst<Int>,
   ): IrConstructorCallImpl = IrConstructorCallImpl.fromSymbolOwner(
-    type = affectedComposableSymbol!!.defaultType,
-    constructorSymbol = affectedComposableSymbol!!.constructors.single(),
+    type = irAffectedComposable.defaultType,
+    constructorSymbol = irAffectedComposable.constructors.single(),
   ).apply {
     putValueArgument(0, composableName)
     putValueArgument(1, packageName)
@@ -50,8 +43,8 @@ public object IrAffectedComposable {
     target: IrConstructorCall,
     composableName: IrConst<String>,
   ): IrConstructorCallImpl = IrConstructorCallImpl.fromSymbolOwner(
-    type = affectedComposableSymbol!!.defaultType,
-    constructorSymbol = affectedComposableSymbol!!.constructors.single(),
+    type = irAffectedComposable.defaultType,
+    constructorSymbol = irAffectedComposable.constructors.single(),
   ).apply {
     putValueArgument(0, composableName)
     putValueArgument(1, target.getValueArgument(1)!!)

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrAffectedField.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrAffectedField.kt
@@ -18,17 +18,10 @@ import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.name.ClassId
 
-public object IrAffectedField {
-  private var affectedFieldSymbol: IrClassSymbol? = null
-  private var valueParameterSymbol: IrClassSymbol? = null
-
-  public val irAffectedField: IrClassSymbol get() = affectedFieldSymbol!!
-
-  public fun init(context: IrPluginContext) {
-    affectedFieldSymbol = context.referenceClass(ClassId.topLevel(AFFECTED_FIELD_FQN))!!
-    valueParameterSymbol = affectedFieldSymbol!!.owner.sealedSubclasses.single { clz ->
-      clz.owner.name == AffectedField_VALUE_PARAMETER
-    }
+public class IrAffectedField(context: IrPluginContext) {
+  public val irAffectedField: IrClassSymbol = context.referenceClass(ClassId.topLevel(AFFECTED_FIELD_FQN))!!
+  private val valueParameterSymbol = irAffectedField.owner.sealedSubclasses.single { clz ->
+    clz.owner.name == AffectedField_VALUE_PARAMETER
   }
 
   public fun irValueParameter(
@@ -38,8 +31,8 @@ public object IrAffectedField {
     valueHashCode: IrExpression,
     stability: IrExpression,
   ): IrConstructorCall = IrConstructorCallImpl.fromSymbolOwner(
-    type = valueParameterSymbol!!.defaultType,
-    constructorSymbol = valueParameterSymbol!!.constructors.single(),
+    type = valueParameterSymbol.defaultType,
+    constructorSymbol = valueParameterSymbol.constructors.single(),
   ).apply {
     putValueArgument(0, name)
     putValueArgument(1, typeFqName)

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -15,6 +15,8 @@ The last tested versions are both `1.6.2`.
 
 ## [Unreleased]
 
+- Eliminated a potential memory leak.
+
 ## [1.5.10-0.1.1] - 2024-03-06
 
 - Fixed #123: Tracking `DerivedState` no longer crashes. Instead, due to technical limitations,


### PR DESCRIPTION
Eliminate a memory leak that could potentially be caused by referencing an outdated `Symbol`.