### PR TITLE
Added API to suppress ComposeInvestigator behavior

### DIFF
--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/names.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/names.kt
@@ -51,6 +51,10 @@ public val STATE_FQN: FqName = FqName("$AndroidxComposeRuntime.State")
 public val ANIMATABLE_FQN: FqName = FqName("androidx.compose.animation.core.Animatable")
 // END Compose Animation
 
+// START NoInvestigation
+public val NO_INVESTIGATION_FQN: FqName = FqName("$ComposeInvestigatorRuntime.NoInvestigation")
+// END NoInvestigation
+
 // START ComposeInvestigatorConfig
 public val COMPOSE_INVESTIGATOR_CONFIG_FQN: FqName = FqName("$ComposeInvestigatorRuntime.ComposeInvestigatorConfig")
 public val ComposeInvestigatorConfig_INVALIDATION_LOGGER: Name = Name.identifier("invalidationLogger")

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoInvalidationTrackingFileLevel.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoInvalidationTrackingFileLevel.kt
@@ -1,0 +1,40 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName")
+@file:NoInvestigation
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("unused")
+@Composable
+private fun Main() {
+  var state by remember { mutableIntStateOf(0) }
+  Button(onClick = { state++ }) {}
+  Counter(count = state)
+  Tv(title = "state", value = state)
+}
+
+@Composable
+private fun Counter(count: Int) {
+  Text(text = "$count")
+}
+
+@Suppress("SameParameterValue")
+@Composable
+private fun Tv(title: String, value: Any) {
+  Text(text = "[$title] $value")
+}

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoInvalidationTrackingFunctionLevel.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoInvalidationTrackingFunctionLevel.kt
@@ -1,0 +1,46 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName")
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("unused")
+@Composable
+private fun Main() {
+  var state by remember { mutableIntStateOf(0) }
+  Button(onClick = { state++ }) {}
+  Counter(count = state)
+  Tv(title = "state", value = state)
+  Hello()
+}
+
+@[NoInvestigation Composable Suppress("UnrememberedMutableState")]
+private fun Counter(count: Int) {
+  val state = mutableIntStateOf(count)
+  Text(text = state.toString())
+}
+
+@[NoInvestigation Composable Suppress("SameParameterValue")]
+private fun Tv(title: String, value: Any) {
+  Text(text = "[$title] $value")
+}
+
+@Composable
+private fun Hello() {
+  BasicText(text = "Hello, World!")
+}

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoStateTracking.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/_source/codegen/NoStateTracking.kt
@@ -1,0 +1,106 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName", "UNUSED_VARIABLE", "unused")
+@file:OptIn(ExperimentalTransitionApi::class)
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.ExperimentalTransitionApi
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStates() {
+  @NoInvestigation val state = object : State<Int> {
+    override val value: Int = 0
+  }
+
+  @NoInvestigation val mutableState = mutableStateOf(0)
+
+  @NoInvestigation val animatable = Animatable(0f)
+
+  @NoInvestigation val animationState = AnimationState(
+    typeConverter = Float.VectorConverter,
+    initialValue = 0f,
+  )
+}
+
+@Suppress("UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStatesDelegation() {
+  @NoInvestigation val state by object : State<Int> {
+    override val value: Int = 0
+  }
+
+  @NoInvestigation val mutableState by mutableStateOf(0)
+
+  @NoInvestigation val animationState by AnimationState(
+    typeConverter = Float.VectorConverter,
+    initialValue = 0f,
+  )
+}
+
+@Composable
+private fun RememberedStates() {
+  @NoInvestigation val state = remember {
+    object : State<Int> {
+      override val value: Int = 0
+    }
+  }
+
+  @NoInvestigation val mutableState = remember { mutableStateOf(0) }
+
+  @NoInvestigation val animatable = remember { Animatable(0f) }
+
+  @NoInvestigation val animationState = remember {
+    AnimationState(
+      typeConverter = Float.VectorConverter,
+      initialValue = 0f,
+    )
+  }
+
+  @NoInvestigation val transitionAnimationState =
+    rememberTransition(transitionState = MutableTransitionState(0f))
+      .animateFloat(label = "unremembered") { prevState -> prevState * 2 }
+
+  @NoInvestigation val infiniteTransition = rememberInfiniteTransition(label = "unremembered")
+}
+
+@Composable
+private fun RememberedStatesDelegation() {
+  @NoInvestigation val state by remember {
+    object : State<Int> {
+      override val value: Int = 0
+    }
+  }
+
+  @NoInvestigation val mutableState by remember { mutableStateOf(0) }
+
+  @NoInvestigation val animationState by remember {
+    AnimationState(
+      typeConverter = Float.VectorConverter,
+      initialValue = 0f,
+    )
+  }
+
+  @NoInvestigation val transitionAnimationState
+    by rememberTransition(transitionState = MutableTransitionState(0f))
+      .animateFloat(label = "unremembered") { prevState -> prevState * 2 }
+}

--- a/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/golden/CodegenTest.kt
+++ b/compiler-integration-test/src/test/kotlin/land/sungbin/composeinvestigator/compiler/test/golden/CodegenTest.kt
@@ -23,11 +23,26 @@ class CodegenTest : AbstractIrTransformTest(useFir = false) {
     )
   }
 
+  @Test fun no_state_tracking_codegen() {
+    verifyGoldenIrTransform(
+      source = sourceString("codegen/NoStateTracking.kt"),
+      flags = CompileFeature_COMPOSE or CompileFeature_NO_CALLSTACK_TRACKING,
+    )
+  }
+
   @Test fun invalidation_tracking_codegen() {
     verifyGoldenIrTransform(
       source = sourceString("codegen/InvalidationTracking.kt"),
       flags = CompileFeature_COMPOSE or CompileFeature_NO_CALLSTACK_TRACKING,
     )
+  }
+
+  @Test fun no_invalidation_tracking_file_level_codegen() {
+    verifyGoldenIrTransform(source = sourceString("codegen/NoInvalidationTrackingFileLevel.kt"))
+  }
+
+  @Test fun no_invalidation_tracking_function_level_codegen() {
+    verifyGoldenIrTransform(source = sourceString("codegen/NoInvalidationTrackingFunctionLevel.kt"))
   }
 
   @Test fun table_intrinsic_call_codegen() {

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_file_level_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_file_level_codegen.txt
@@ -1,0 +1,175 @@
+//
+// Source
+// ------------------------------------------
+
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName")
+@file:NoInvestigation
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("unused")
+@Composable
+private fun Main() {
+  var state by remember { mutableIntStateOf(0) }
+  Button(onClick = { state++ }) {}
+  Counter(count = state)
+  Tv(title = "state", value = state)
+}
+
+@Composable
+private fun Counter(count: Int) {
+  Text(text = "$count")
+}
+
+@Suppress("SameParameterValue")
+@Composable
+private fun Tv(title: String, value: Any) {
+  Text(text = "[$title] $value")
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+val ComposableCallstackTrackerImpl%TestKt: Stack<String> = Stack()
+@Suppress(names = "unused")
+@Composable
+@ComposableTarget(applier = "androidx.compose.ui.UiComposable")
+private fun Main(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    var state by {
+      val state%delegate = <block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp0_group = %composer.cache(false) {
+          mutableIntStateOf(0)
+        }
+        %composer.endReplaceableGroup()
+        tmp0_group
+      }
+      get() {
+        return state%delegate.getValue(null, ::state%delegate)
+      }
+      set(value: Int) {
+        return state%delegate.setValue(null, ::state%delegate, value)
+      }
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Button(<block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp1_group = %composer.cache(false) {
+          {
+            <get-state>()++
+          }
+        }
+        %composer.endReplaceableGroup()
+        tmp1_group
+      }, null, false, null, null, null, null, null, null, ComposableSingletons%TestKt.lambda-1, %composer, 0b00110000000000000000000000000110, 0b000111111110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Counter(<get-state>(), %composer, 0)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Tv("state", <get-state>(), %composer, 0b0110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Main(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Composable
+@ComposableTarget(applier = "androidx.compose.ui.UiComposable")
+private fun Counter(count: Int, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  val %dirty = %changed
+  if (%changed and 0b1110 == 0) {
+    %dirty = %dirty or if (%composer.changed(count)) 0b0100 else 0b0010
+  }
+  if (%dirty and 0b1011 != 0b0010 || !%composer.skipping) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Counter")
+      Text("%count", null, <unsafe-coerce>(0L), <unsafe-coerce>(0L), null, null, null, <unsafe-coerce>(0L), null, null, <unsafe-coerce>(0L), <unsafe-coerce>(0), false, 0, 0, null, null, %composer, 0, 0, 0b00011111111111111110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Counter(count, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Suppress(names = "SameParameterValue")
+@Composable
+private fun Tv(title: String, value: Any, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (isTraceInProgress()) {
+    traceEventStart(<>, %changed, -1, <>)
+  }
+  try {
+    ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Tv")
+    Text("[%title] %value", null, <unsafe-coerce>(0L), <unsafe-coerce>(0L), null, null, null, <unsafe-coerce>(0L), null, null, <unsafe-coerce>(0L), <unsafe-coerce>(0), false, 0, 0, null, null, %composer, 0, 0, 0b00011111111111111110)
+  } finally {
+    ComposableCallstackTrackerImpl%TestKt.pop()
+  }
+  if (isTraceInProgress()) {
+    traceEventEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Tv(title, value, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+internal object ComposableSingletons%TestKt {
+  val lambda-1: @[ExtensionFunctionType] Function3<RowScope, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+    if (%changed and 0b01010001 != 0b00010000 || !%composer.skipping) {
+      if (isTraceInProgress()) {
+        traceEventStart(<>, %changed, -1, <>)
+      }
+      Unit
+      if (isTraceInProgress()) {
+        traceEventEnd()
+      }
+    } else {
+      %composer.skipToGroupEnd()
+    }
+  }
+}

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_function_level_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_function_level_codegen.txt
@@ -1,0 +1,241 @@
+//
+// Source
+// ------------------------------------------
+
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName")
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("unused")
+@Composable
+private fun Main() {
+  var state by remember { mutableIntStateOf(0) }
+  Button(onClick = { state++ }) {}
+  Counter(count = state)
+  Tv(title = "state", value = state)
+  Hello()
+}
+
+@[NoInvestigation Composable Suppress("UnrememberedMutableState")]
+private fun Counter(count: Int) {
+  val state = mutableIntStateOf(count)
+  Text(text = state.toString())
+}
+
+@[NoInvestigation Composable Suppress("SameParameterValue")]
+private fun Tv(title: String, value: Any) {
+  Text(text = "[$title] $value")
+}
+
+@Composable
+private fun Hello() {
+  BasicText(text = "Hello, World!")
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+val ComposableInvalidationTrackTableImpl%TestKt: ComposableInvalidationTrackTable = ComposableInvalidationTrackTable()
+val ComposableCallstackTrackerImpl%TestKt: Stack<String> = Stack()
+@Suppress(names = "unused")
+@Composable
+@ComposableTarget(applier = "androidx.compose.ui.UiComposable")
+private fun Main(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_Main%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(tmp1_Main%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(tmp1_Main%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    var state by {
+      val state%delegate = %composer.startReplaceableGroup(<>)
+      val tmp0_group = %composer.cache(false) {
+        mutableIntStateOf(0)
+      }
+      %composer.endReplaceableGroup()
+      tmp0_group.registerStateObjectTracking(
+        composer = %composer,
+        composable = AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8),
+        composableKeyName = "fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt",
+        stateName = "state"
+      )
+      get() {
+        return state%delegate.getValue(null, ::state%delegate)
+      }
+      set(value: Int) {
+        return state%delegate.setValue(null, ::state%delegate, value)
+      }
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Button(<block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp1_group = %composer.cache(false) {
+          {
+            <get-state>()++
+          }
+        }
+        %composer.endReplaceableGroup()
+        tmp1_group
+      }, null, false, null, null, null, null, null, null, ComposableSingletons%TestKt.lambda-1, %composer, 0b00110000000000000000000000000110, 0b000111111110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Counter(<get-state>(), %composer, 0)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Tv("state", <get-state>(), %composer, 0b0110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Main")
+      Hello(%composer, 0)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(Invalidate))
+    Main(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@NoInvestigation
+@Composable
+@Suppress(names = "UnrememberedMutableState")
+@ComposableTarget(applier = "androidx.compose.ui.UiComposable")
+private fun Counter(count: Int, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  val %dirty = %changed
+  if (%changed and 0b1110 == 0) {
+    %dirty = %dirty or if (%composer.changed(count)) 0b0100 else 0b0010
+  }
+  if (%dirty and 0b1011 != 0b0010 || !%composer.skipping) {
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %dirty, -1, <>)
+    }
+    val state = mutableIntStateOf(count)
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Counter")
+      Text(state.toString(), null, <unsafe-coerce>(0L), <unsafe-coerce>(0L), null, null, null, <unsafe-coerce>(0L), null, null, <unsafe-coerce>(0L), <unsafe-coerce>(0), false, 0, 0, null, null, %composer, 0, 0, 0b00011111111111111110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Counter(count, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@NoInvestigation
+@Composable
+@Suppress(names = "SameParameterValue")
+private fun Tv(title: String, value: Any, %composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (isTraceInProgress()) {
+    traceEventStart(<>, %changed, -1, <>)
+  }
+  try {
+    ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Tv")
+    Text("[%title] %value", null, <unsafe-coerce>(0L), <unsafe-coerce>(0L), null, null, null, <unsafe-coerce>(0L), null, null, <unsafe-coerce>(0L), <unsafe-coerce>(0), false, 0, 0, null, null, %composer, 0, 0, 0b00011111111111111110)
+  } finally {
+    ComposableCallstackTrackerImpl%TestKt.pop()
+  }
+  if (isTraceInProgress()) {
+    traceEventEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    Tv(title, value, %composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Composable
+@ComposableTarget(applier = "androidx.compose.ui.UiComposable")
+private fun Hello(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_Hello%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(tmp1_Hello%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(tmp1_Hello%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    try {
+      ComposableCallstackTrackerImpl%TestKt.push("land.sungbin.composeinvestigator.compiler.test._source.codegen.Hello")
+      BasicText("Hello, World!", null, null, null, <unsafe-coerce>(0), false, 0, 0, null, %composer, 0b0110, 0b000111111110)
+    } finally {
+      ComposableCallstackTrackerImpl%TestKt.pop()
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(Invalidate))
+    Hello(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+internal object ComposableSingletons%TestKt {
+  val lambda-1: @[ExtensionFunctionType] Function3<RowScope, Composer, Int, Unit> = composableLambdaInstance(<>, false) { %composer: Composer?, %changed: Int ->
+    if (%changed and 0b01010001 != 0b00010000 || !%composer.skipping) {
+      val tmp0_affectFields = mutableListOf()
+      val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Processed(tmp1_<anonymous>%validationReason))
+      ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Processed(tmp1_<anonymous>%validationReason))
+      if (isTraceInProgress()) {
+        traceEventStart(<>, %changed, -1, <>)
+      }
+      Unit
+      if (isTraceInProgress()) {
+        traceEventEnd()
+      }
+    } else {
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Skipped)
+      ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Skipped)
+      %composer.skipToGroupEnd()
+    }
+  }
+}

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_state_tracking_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_state_tracking_codegen.txt
@@ -1,0 +1,384 @@
+//
+// Source
+// ------------------------------------------
+
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+@file:Suppress("TestFunctionName", "UNUSED_VARIABLE", "unused")
+@file:OptIn(ExperimentalTransitionApi::class)
+
+package land.sungbin.composeinvestigator.compiler.test._source.codegen
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.ExperimentalTransitionApi
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import land.sungbin.composeinvestigator.runtime.NoInvestigation
+
+@Suppress("UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStates() {
+  @NoInvestigation val state = object : State<Int> {
+    override val value: Int = 0
+  }
+
+  @NoInvestigation val mutableState = mutableStateOf(0)
+
+  @NoInvestigation val animatable = Animatable(0f)
+
+  @NoInvestigation val animationState = AnimationState(
+    typeConverter = Float.VectorConverter,
+    initialValue = 0f,
+  )
+}
+
+@Suppress("UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStatesDelegation() {
+  @NoInvestigation val state by object : State<Int> {
+    override val value: Int = 0
+  }
+
+  @NoInvestigation val mutableState by mutableStateOf(0)
+
+  @NoInvestigation val animationState by AnimationState(
+    typeConverter = Float.VectorConverter,
+    initialValue = 0f,
+  )
+}
+
+@Composable
+private fun RememberedStates() {
+  @NoInvestigation val state = remember {
+    object : State<Int> {
+      override val value: Int = 0
+    }
+  }
+
+  @NoInvestigation val mutableState = remember { mutableStateOf(0) }
+
+  @NoInvestigation val animatable = remember { Animatable(0f) }
+
+  @NoInvestigation val animationState = remember {
+    AnimationState(
+      typeConverter = Float.VectorConverter,
+      initialValue = 0f,
+    )
+  }
+
+  @NoInvestigation val transitionAnimationState =
+    rememberTransition(transitionState = MutableTransitionState(0f))
+      .animateFloat(label = "unremembered") { prevState -> prevState * 2 }
+
+  @NoInvestigation val infiniteTransition = rememberInfiniteTransition(label = "unremembered")
+}
+
+@Composable
+private fun RememberedStatesDelegation() {
+  @NoInvestigation val state by remember {
+    object : State<Int> {
+      override val value: Int = 0
+    }
+  }
+
+  @NoInvestigation val mutableState by remember { mutableStateOf(0) }
+
+  @NoInvestigation val animationState by remember {
+    AnimationState(
+      typeConverter = Float.VectorConverter,
+      initialValue = 0f,
+    )
+  }
+
+  @NoInvestigation val transitionAnimationState
+    by rememberTransition(transitionState = MutableTransitionState(0f))
+      .animateFloat(label = "unremembered") { prevState -> prevState * 2 }
+}
+
+//
+// Transformed IR
+// ------------------------------------------
+
+val ComposableInvalidationTrackTableImpl%TestKt: ComposableInvalidationTrackTable = ComposableInvalidationTrackTable()
+@Suppress(names = "UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStates(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_UnrememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp1_UnrememberedStates%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp1_UnrememberedStates%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    val state = <block>{
+      object : State<Int> {
+        val value: Int = 0
+      }
+    }
+    val mutableState = mutableStateOf(
+      value = 0
+    )
+    val animatable = Animatable(
+      initialValue = 0.0f
+    )
+    val animationState = AnimationState(
+      typeConverter = Companion.VectorConverter,
+      initialValue = 0.0f
+    )
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
+    UnrememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Suppress(names = "UnrememberedMutableState", "UnrememberedAnimatable")
+@Composable
+private fun UnrememberedStatesDelegation(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_UnrememberedStatesDelegation%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(tmp1_UnrememberedStatesDelegation%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(tmp1_UnrememberedStatesDelegation%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    @NoInvestigation
+    val state by {
+      val state%delegate = <block>{
+        object : State<Int> {
+          val value: Int = 0
+        }
+      }
+      get() {
+        return state%delegate.getValue(null, ::state%delegate)
+      }
+    }
+    @NoInvestigation
+    val mutableState by {
+      val mutableState%delegate = mutableStateOf(
+        value = 0
+      )
+      get() {
+        return mutableState%delegate.getValue(null, ::mutableState%delegate)
+      }
+    }
+    @NoInvestigation
+    val animationState by {
+      val animationState%delegate = AnimationState(
+        typeConverter = Companion.VectorConverter,
+        initialValue = 0.0f
+      )
+      get() {
+        return animationState%delegate.getValue(null, ::animationState%delegate)
+      }
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(Invalidate))
+    UnrememberedStatesDelegation(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Composable
+private fun RememberedStates(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_RememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(tmp1_RememberedStates%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(tmp1_RememberedStates%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    val state = <block>{
+      %composer.startReplaceableGroup(<>)
+      val tmp0_group = %composer.cache(false) {
+        object : State<Int> {
+          val value: Int = 0
+        }
+      }
+      %composer.endReplaceableGroup()
+      tmp0_group
+    }
+    val mutableState = <block>{
+      %composer.startReplaceableGroup(<>)
+      val tmp1_group = %composer.cache(false) {
+        mutableStateOf(
+          value = 0
+        )
+      }
+      %composer.endReplaceableGroup()
+      tmp1_group
+    }
+    val animatable = <block>{
+      %composer.startReplaceableGroup(<>)
+      val tmp2_group = %composer.cache(false) {
+        Animatable(
+          initialValue = 0.0f
+        )
+      }
+      %composer.endReplaceableGroup()
+      tmp2_group
+    }
+    val animationState = <block>{
+      %composer.startReplaceableGroup(<>)
+      val tmp3_group = %composer.cache(false) {
+        AnimationState(
+          typeConverter = Companion.VectorConverter,
+          initialValue = 0.0f
+        )
+      }
+      %composer.endReplaceableGroup()
+      tmp3_group
+    }
+    val transitionAnimationState = rememberTransition(MutableTransitionState(0.0f), null, %composer, MutableTransitionState.%stable, 0b0010).animateFloat(null, "unremembered", { prevState: Float, %composer: Composer?, %changed: Int ->
+      %composer.startReplaceableGroup(<>)
+      if (isTraceInProgress()) {
+        traceEventStart(<>, %changed, -1, <>)
+      }
+      val tmp0 = prevState * 2
+      if (isTraceInProgress()) {
+        traceEventEnd()
+      }
+      %composer.endReplaceableGroup()
+      tmp0
+    }, %composer, 0b000110000000, 0b0001)
+    val infiniteTransition = rememberInfiniteTransition("unremembered", %composer, 0b0110, 0)
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(Invalidate))
+    RememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}
+@Composable
+private fun RememberedStatesDelegation(%composer: Composer?, %changed: Int) {
+  %composer = %composer.startRestartGroup(<>)
+  if (%changed != 0 || !%composer.skipping) {
+    val tmp0_affectFields = mutableListOf()
+    val tmp1_RememberedStatesDelegation%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(tmp1_RememberedStatesDelegation%validationReason))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(tmp1_RememberedStatesDelegation%validationReason))
+    if (isTraceInProgress()) {
+      traceEventStart(<>, %changed, -1, <>)
+    }
+    @NoInvestigation
+    val state by {
+      val state%delegate = <block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp0_group = %composer.cache(false) {
+          object : State<Int> {
+            val value: Int = 0
+          }
+        }
+        %composer.endReplaceableGroup()
+        tmp0_group
+      }
+      get() {
+        return state%delegate.getValue(null, ::state%delegate)
+      }
+    }
+    @NoInvestigation
+    val mutableState by {
+      val mutableState%delegate = <block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp1_group = %composer.cache(false) {
+          mutableStateOf(
+            value = 0
+          )
+        }
+        %composer.endReplaceableGroup()
+        tmp1_group
+      }
+      get() {
+        return mutableState%delegate.getValue(null, ::mutableState%delegate)
+      }
+    }
+    @NoInvestigation
+    val animationState by {
+      val animationState%delegate = <block>{
+        %composer.startReplaceableGroup(<>)
+        val tmp2_group = %composer.cache(false) {
+          AnimationState(
+            typeConverter = Companion.VectorConverter,
+            initialValue = 0.0f
+          )
+        }
+        %composer.endReplaceableGroup()
+        tmp2_group
+      }
+      get() {
+        return animationState%delegate.getValue(null, ::animationState%delegate)
+      }
+    }
+    @NoInvestigation
+    val transitionAnimationState by {
+      val transitionAnimationState%delegate = rememberTransition(MutableTransitionState(0.0f), null, %composer, MutableTransitionState.%stable, 0b0010).animateFloat(null, "unremembered", { prevState: Float, %composer: Composer?, %changed: Int ->
+        %composer.startReplaceableGroup(<>)
+        if (isTraceInProgress()) {
+          traceEventStart(<>, %changed, -1, <>)
+        }
+        val tmp0 = prevState * 2
+        if (isTraceInProgress()) {
+          traceEventEnd()
+        }
+        %composer.endReplaceableGroup()
+        tmp0
+      }, %composer, 0b000110000000, 0b0001)
+      get() {
+        return transitionAnimationState%delegate.getValue(null, ::transitionAnimationState%delegate)
+      }
+    }
+    if (isTraceInProgress()) {
+      traceEventEnd()
+    }
+  } else {
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Skipped)
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Skipped)
+    %composer.skipToGroupEnd()
+  }
+  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(Invalidate))
+    ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(Invalidate))
+    RememberedStatesDelegation(%composer, updateChangedFlags(%changed or 0b0001))
+  }
+}

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -16,6 +16,7 @@ The last tested versions are both `1.6.2`.
 ## [Unreleased]
 
 - Eliminated a potential memory leak.
+- Adds the `@NoInvestigation` API to suppress the workings of ComposeInvestigator.
 
 ## [1.5.10-0.1.1] - 2024-03-06
 

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTable.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTable.kt
@@ -51,6 +51,10 @@ public operator fun ComposableName.getValue(thisRef: Any?, property: Any?): Stri
  *
  * To get the instance of [ComposableInvalidationTrackTable] created in the current file,
  * use [currentComposableInvalidationTracker].
+ *
+ * If a file is annotated with [NoInvestigation], this class will not be instantiated in
+ * that file. If you use this class's APIs, including the [currentComposableInvalidationTracker]
+ * API, without being instantiated, you will receive a runtime error.
  */
 @ExperimentalComposeInvestigatorApi
 @Immutable

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/NoInvestigation.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/NoInvestigation.kt
@@ -1,0 +1,39 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/ComposeInvestigator/blob/main/LICENSE
+ */
+
+package land.sungbin.composeinvestigator.runtime
+
+/**
+ * ComposeInvestigator does not work on annotated (1) files,
+ * (2) composable functions, or (3, 4) state variables.
+ *
+ * 1. `@file:NoInvestigation`
+ * 2. `@NoInvestigation @Composable fun MyComposable()`
+ * 3. `@NoInvestigation val myState = mutableStateOf(0)`
+ * 4. `@NoInvestigation val myState by mutableStateOf(0)`
+ *
+ * If a composable function is annotated with this, state variable tracking
+ * in the function body is also disabled. If you want to disable tracking
+ * for a composable function, but want to enable tracking of state variables
+ * in the body of that function, you must enable it directly with the
+ * [registerStateObjectTracking] API.
+ *
+ * ```
+ * @Composable @NoInvestigation fun MyComposable() {
+ *   val state = remember { mutableStateOf(1).registerStateObjectTracking() }
+ *   // Or, you can use delegation.
+ *   val state2 by remember { mutableStateOf(1).registerStateObjectTracking() }
+ * }
+ * ```
+ *
+ * Callstack tracing always works regardless of this annotation, meaning that
+ * even if a composable in the middle of a callstack is annotated with [NoInvestigation],
+ * the final callstack will still show the middle composable without loss.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FILE, AnnotationTarget.FUNCTION, AnnotationTarget.LOCAL_VARIABLE)
+public annotation class NoInvestigation


### PR DESCRIPTION
Adds the `@NoInvestigation` API to suppress the workings of ComposeInvestigator.