### PR TITLE
Pass the callstack information to the `ComposableInvalidationListener`

### DIFF
--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/ComposableInvalidationTrackingTransformer.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/lower/ComposableInvalidationTrackingTransformer.kt
@@ -167,15 +167,18 @@ internal class ComposableInvalidationTrackingTransformer(
       invalidationLogger.irInvalidationTypeProcessed(reason = irGetValue(computeInvalidationReasonVariable))
         .apply { type = invalidationTypeSymbol.defaultType }
 
+    val currentCallstack = currentCallstack()
+
     val callListeners = currentInvalidationTrackTable.irCallListeners(
       key = irString(currentKey.keyName),
+      callstack = currentCallstack,
       composable = currentKey.affectedComposable,
       type = invalidationTypeProcessed,
     )
     newStatements += callListeners
 
     val logger = invalidationLogger.irLog(
-      callstack = currentCallstack(),
+      callstack = currentCallstack,
       affectedComposable = currentKey.affectedComposable,
       invalidationType = invalidationTypeProcessed,
     )
@@ -211,15 +214,18 @@ internal class ComposableInvalidationTrackingTransformer(
       type = invalidationTypeSymbol.defaultType
     }
 
+    val currentCallstack = currentCallstack()
+
     val callListeners = currentInvalidationTrackTable.irCallListeners(
       key = irString(currentKey.keyName),
+      callstack = currentCallstack,
       composable = currentKey.affectedComposable,
       type = invalidationTypeProcessed,
     )
     newStatements += callListeners
 
     val logger = invalidationLogger.irLog(
-      callstack = currentCallstack(),
+      callstack = currentCallstack,
       affectedComposable = currentKey.affectedComposable,
       invalidationType = invalidationTypeProcessed,
     )
@@ -246,13 +252,16 @@ internal class ComposableInvalidationTrackingTransformer(
     val invalidationTypeSkipped = invalidationLogger.irInvalidationTypeSkipped()
       .apply { type = invalidationTypeSymbol.defaultType }
 
+    val currentCallstack = currentCallstack()
+
     val callListeners = currentInvalidationTrackTable.irCallListeners(
       key = irString(currentKey.keyName),
+      callstack = currentCallstack,
       composable = currentKey.affectedComposable,
       type = invalidationTypeSkipped,
     )
     val logger = invalidationLogger.irLog(
-      callstack = currentCallstack(),
+      callstack = currentCallstack,
       affectedComposable = currentKey.affectedComposable,
       invalidationType = invalidationTypeSkipped,
     )

--- a/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrInvalidationTrackTable.kt
+++ b/compiler-hosted/src/main/kotlin/land/sungbin/composeinvestigator/compiler/struct/IrInvalidationTrackTable.kt
@@ -48,6 +48,7 @@ public class IrInvalidationTrackTable private constructor(public val prop: IrPro
 
   public fun irCallListeners(
     key: IrConst<String>,
+    callstack: IrDeclarationReference,
     composable: IrDeclarationReference,
     type: IrDeclarationReference,
   ): IrCall = IrCallImpl.fromSymbolOwner(
@@ -58,8 +59,9 @@ public class IrInvalidationTrackTable private constructor(public val prop: IrPro
     fn.dispatchReceiver = propGetter()
   }.apply {
     putValueArgument(0, key)
-    putValueArgument(1, composable)
-    putValueArgument(2, type)
+    putValueArgument(1, callstack)
+    putValueArgument(2, composable)
+    putValueArgument(3, type)
   }
 
   public fun irComputeInvalidationReason(

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/callback/Effects.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/callback/Effects.kt
@@ -22,7 +22,7 @@ fun Effects_InvalidationSkippedRoot() {
   val currentKeyName = table.currentComposableKeyName
 
   ComposableInvalidationEffect(table = table, composableKey = currentKeyName) {
-    ComposableInvalidationListener { composable, type ->
+    ComposableInvalidationListener { _, composable, type ->
       invalidationListensViaEffects.getOrPut(composable, ::mutableListOf).add(type)
     }
   }
@@ -37,7 +37,7 @@ private fun Effects_InvalidationSkippedChild() {
   val currentKeyName = table.currentComposableKeyName
 
   ComposableInvalidationEffect(table = table, composableKey = currentKeyName) {
-    ComposableInvalidationListener { composable, type ->
+    ComposableInvalidationListener { _, composable, type ->
       invalidationListensViaEffects.getOrPut(composable, ::mutableListOf).add(type)
     }
   }

--- a/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/callback/RegisterListener.kt
+++ b/compiler-integration-test/src/main/kotlin/land/sungbin/composeinvestigator/compiler/test/source/table/callback/RegisterListener.kt
@@ -18,7 +18,7 @@ fun RegisterListener_InvalidationSkippedRoot() {
   val recomposeScope = currentRecomposeScope
   val tracker = currentComposableInvalidationTracker
 
-  tracker.registerListener(keyName = tracker.currentComposableKeyName) { composable, type ->
+  tracker.registerListener(keyName = tracker.currentComposableKeyName) { _, composable, type ->
     invalidationListensViaManualRegister.getOrPut(composable, ::mutableListOf).add(type)
   }
 
@@ -30,7 +30,7 @@ fun RegisterListener_InvalidationSkippedRoot() {
 private fun RegisterListener_InvalidationSkippedChild() {
   val tracker = currentComposableInvalidationTracker
 
-  tracker.registerListener(keyName = tracker.currentComposableKeyName) { composable, type ->
+  tracker.registerListener(keyName = tracker.currentComposableKeyName) { _, composable, type ->
     invalidationListensViaManualRegister.getOrPut(composable, ::mutableListOf).add(type)
   }
 

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/callstack_tracking_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/callstack_tracking_codegen.txt
@@ -77,7 +77,7 @@ private fun Main(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_Main%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -110,12 +110,12 @@ private fun Main(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
     Main(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -127,7 +127,7 @@ private fun Sub(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_Sub%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(tmp1_Sub%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(tmp1_Sub%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(tmp1_Sub%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -142,12 +142,12 @@ private fun Sub(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Sub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Sub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 34, 8), Processed(Invalidate))
     Sub(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -159,7 +159,7 @@ private fun DoubleSub(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_DoubleSub%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(tmp1_DoubleSub%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(tmp1_DoubleSub%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(tmp1_DoubleSub%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -175,12 +175,12 @@ private fun DoubleSub(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DoubleSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DoubleSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 39, 8), Processed(Invalidate))
     DoubleSub(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -192,7 +192,7 @@ private fun DeepestSub(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_DeepestSub%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(tmp1_DeepestSub%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(tmp1_DeepestSub%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(tmp1_DeepestSub%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -207,12 +207,12 @@ private fun DeepestSub(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-DeepestSub(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("DeepestSub", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 45, 8), Processed(Invalidate))
     DeepestSub(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -237,7 +237,7 @@ private fun VarargContents(contents: Array<out Function2<Composer, Int, Unit>>, 
     val tmp1_contents%valueParam = ValueParameter("contents", "kotlin.Array", contents.toString(), contents.hashCode(), Certain(false))
     tmp0_affectFields.add(tmp1_contents%valueParam)
     val tmp2_VarargContents%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(tmp2_VarargContents%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(tmp2_VarargContents%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(tmp2_VarargContents%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %dirty, -1, <>)
@@ -254,12 +254,12 @@ private fun VarargContents(contents: Array<out Function2<Composer, Int, Unit>>, 
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-VarargContents(Array,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("VarargContents", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 58, 8), Processed(Invalidate))
     VarargContents(*contents, %composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -269,7 +269,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b1011 != 0b0010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -284,7 +284,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 10), Skipped)
       %composer.skipToGroupEnd()
     }
@@ -293,7 +293,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b1011 != 0b0010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-2/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-2/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-2/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -308,7 +308,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-2/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-2/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-2", "/Test.kt", 27, 4), Skipped)
       %composer.skipToGroupEnd()
     }
@@ -317,7 +317,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b1011 != 0b0010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-3/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-3/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-3/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -332,7 +332,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-3/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-3/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-3", "/Test.kt", 28, 4), Skipped)
       %composer.skipToGroupEnd()
     }
@@ -341,7 +341,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b1011 != 0b0010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-4/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-4/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-4/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -356,7 +356,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-4/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-4/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-4", "/Test.kt", 29, 4), Skipped)
       %composer.skipToGroupEnd()
     }
@@ -369,7 +369,7 @@ internal object ComposableSingletons%TestKt {
     if (%dirty and 0b01011011 != 0b00010010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-BoxWithConstraintsScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-5/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-BoxWithConstraintsScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-5/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-BoxWithConstraintsScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-5/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %dirty, -1, <>)
@@ -384,7 +384,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-BoxWithConstraintsScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-5/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-BoxWithConstraintsScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-5/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-5", "/Test.kt", 49, 27), Skipped)
       %composer.skipToGroupEnd()
     }
@@ -393,7 +393,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b1011 != 0b0010 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-6/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-6/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-6/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -422,7 +422,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-6/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-6/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-6", "/Test.kt", 46, 10), Skipped)
       %composer.skipToGroupEnd()
     }

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/invalidation_tracking_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/invalidation_tracking_codegen.txt
@@ -54,7 +54,7 @@ private fun Main(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_Main%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(tmp1_Main%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -94,12 +94,12 @@ private fun Main(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 22, 8), Processed(Invalidate))
     Main(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -117,7 +117,7 @@ private fun Counter(count: Int, %composer: Composer?, %changed: Int) {
     val tmp1_count%valueParam = ValueParameter("count", "kotlin.Int", count.toString(), count.hashCode(), Certain(true))
     tmp0_affectFields.add(tmp1_count%valueParam)
     val tmp2_Counter%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp2_Counter%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp2_Counter%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp2_Counter%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %dirty, -1, <>)
@@ -127,12 +127,12 @@ private fun Counter(count: Int, %composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Counter(Int,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Counter", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
     Counter(count, %composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -146,7 +146,7 @@ private fun Tv(title: String, value: Any, %composer: Composer?, %changed: Int) {
   val tmp2_value%valueParam = ValueParameter("value", "kotlin.Any", value.toString(), value.hashCode(), Certain(false))
   tmp0_affectFields.add(tmp2_value%valueParam)
   val tmp3_Tv%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Tv(String,Any,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-  ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Tv(String,Any,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(tmp3_Tv%validationReason))
+  ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Tv(String,Any,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(tmp3_Tv%validationReason))
   ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(tmp3_Tv%validationReason))
   %composer = %composer.startRestartGroup(<>)
   if (isTraceInProgress()) {
@@ -157,7 +157,7 @@ private fun Tv(title: String, value: Any, %composer: Composer?, %changed: Int) {
     traceEventEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Tv(String,Any,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Tv(String,Any,Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("Tv", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 36, 8), Processed(Invalidate))
     Tv(title, value, %composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -167,7 +167,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b01010001 != 0b00010000 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -177,7 +177,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 24, 32), Skipped)
       %composer.skipToGroupEnd()
     }

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_function_level_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_invalidation_tracking_function_level_codegen.txt
@@ -63,7 +63,7 @@ private fun Main(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_Main%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(tmp1_Main%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(tmp1_Main%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(tmp1_Main%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -124,12 +124,12 @@ private fun Main(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Main(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Main", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 24, 8), Processed(Invalidate))
     Main(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -193,7 +193,7 @@ private fun Hello(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_Hello%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(tmp1_Hello%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(tmp1_Hello%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(tmp1_Hello%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -208,12 +208,12 @@ private fun Hello(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-Hello(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("Hello", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 44, 8), Processed(Invalidate))
     Hello(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -223,7 +223,7 @@ internal object ComposableSingletons%TestKt {
     if (%changed and 0b01010001 != 0b00010000 || !%composer.skipping) {
       val tmp0_affectFields = mutableListOf()
       val tmp1_<anonymous>%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Processed(tmp1_<anonymous>%validationReason))
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Processed(tmp1_<anonymous>%validationReason))
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Processed(tmp1_<anonymous>%validationReason))
       if (isTraceInProgress()) {
         traceEventStart(<>, %changed, -1, <>)
@@ -233,7 +233,7 @@ internal object ComposableSingletons%TestKt {
         traceEventEnd()
       }
     } else {
-      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Skipped)
+      ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RowScope.%anonymous%(Composer,Int)Unit/arg-2/call-composableLambdaInstance/val-lambda-1/class-ComposableSingletons%TestKt/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Skipped)
       ComposeInvestigatorConfig.invalidationLogger(ComposableCallstackTrackerImpl%TestKt.toList(), AffectedComposable("<anonymous>", "land.sungbin.composeinvestigator.compiler.test._source.codegen.ComposableSingletons%TestKt.lambda-1", "/Test.kt", 26, 32), Skipped)
       %composer.skipToGroupEnd()
     }

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_state_tracking_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/no_state_tracking_codegen.txt
@@ -121,7 +121,7 @@ private fun UnrememberedStates(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_UnrememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp1_UnrememberedStates%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp1_UnrememberedStates%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(tmp1_UnrememberedStates%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -145,12 +145,12 @@ private fun UnrememberedStates(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 30, 8), Processed(Invalidate))
     UnrememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -162,7 +162,7 @@ private fun UnrememberedStatesDelegation(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_UnrememberedStatesDelegation%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(tmp1_UnrememberedStatesDelegation%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(tmp1_UnrememberedStatesDelegation%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(tmp1_UnrememberedStatesDelegation%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -201,12 +201,12 @@ private fun UnrememberedStatesDelegation(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 47, 8), Processed(Invalidate))
     UnrememberedStatesDelegation(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -217,7 +217,7 @@ private fun RememberedStates(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_RememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(tmp1_RememberedStates%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(tmp1_RememberedStates%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(tmp1_RememberedStates%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -280,12 +280,12 @@ private fun RememberedStates(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 61, 8), Processed(Invalidate))
     RememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -296,7 +296,7 @@ private fun RememberedStatesDelegation(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_RememberedStatesDelegation%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(tmp1_RememberedStatesDelegation%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(tmp1_RememberedStatesDelegation%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(tmp1_RememberedStatesDelegation%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -372,12 +372,12 @@ private fun RememberedStatesDelegation(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStatesDelegation(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStatesDelegation", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 87, 8), Processed(Invalidate))
     RememberedStatesDelegation(%composer, updateChangedFlags(%changed or 0b0001))
   }

--- a/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/state_tracking_codegen.txt
+++ b/compiler-integration-test/src/test/resources/golden/land.sungbin.composeinvestigator.compiler.test.golden.CodegenTest/state_tracking_codegen.txt
@@ -74,7 +74,7 @@ private fun UnrememberedStates(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_UnrememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(tmp1_UnrememberedStates%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(tmp1_UnrememberedStates%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(tmp1_UnrememberedStates%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -117,12 +117,12 @@ private fun UnrememberedStates(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-UnrememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("UnrememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 28, 8), Processed(Invalidate))
     UnrememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
   }
@@ -133,7 +133,7 @@ private fun RememberedStates(%composer: Composer?, %changed: Int) {
   if (%changed != 0 || !%composer.skipping) {
     val tmp0_affectFields = mutableListOf()
     val tmp1_RememberedStates%validationReason = ComposableInvalidationTrackTableImpl%TestKt.computeInvalidationReason("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", tmp0_affectFields)
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(tmp1_RememberedStates%validationReason))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(tmp1_RememberedStates%validationReason))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(tmp1_RememberedStates%validationReason))
     if (isTraceInProgress()) {
       traceEventStart(<>, %changed, -1, <>)
@@ -213,12 +213,12 @@ private fun RememberedStates(%composer: Composer?, %changed: Int) {
       traceEventEnd()
     }
   } else {
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Skipped)
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Skipped)
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Skipped)
     %composer.skipToGroupEnd()
   }
   %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
-    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(Invalidate))
+    ComposableInvalidationTrackTableImpl%TestKt.callListeners("fun-RememberedStates(Composer,Int)Unit/pkg-land.sungbin.composeinvestigator.compiler.test._source.codegen/file-Test.kt", emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(Invalidate))
     ComposeInvestigatorConfig.invalidationLogger(emptyList(), AffectedComposable("RememberedStates", "land.sungbin.composeinvestigator.compiler.test._source.codegen", "/Test.kt", 41, 8), Processed(Invalidate))
     RememberedStates(%composer, updateChangedFlags(%changed or 0b0001))
   }

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -17,6 +17,7 @@ The last tested versions are both `1.6.2`.
 
 - Eliminated a potential memory leak.
 - Adds the `@NoInvestigation` API to suppress the workings of ComposeInvestigator.
+- Fixed #121: Now pass the callstack information to the `ComposableInvalidationListener`.
 
 ## [1.5.10-0.1.1] - 2024-03-06
 

--- a/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTable.kt
+++ b/runtime/src/main/kotlin/land/sungbin/composeinvestigator/runtime/ComposableInvalidationTrackTable.kt
@@ -24,7 +24,12 @@ public val currentComposableInvalidationTracker: ComposableInvalidationTrackTabl
 
 /** A callback that is called whenever a composable is invalidated (recomposed) */
 public fun interface ComposableInvalidationListener {
-  public fun onInvalidate(composable: AffectedComposable, type: ComposableInvalidationType)
+  /**
+   * @param callstack *(Experimental. This value may be produces wrong result.)*
+   * Represents all call stacks leading up to the current composable being called
+   * (each shown as a fully-qualified name or simple name).
+   */
+  public fun onInvalidate(callstack: List<String>, composable: AffectedComposable, type: ComposableInvalidationType)
 }
 
 // We use an annotation class to prevent LiveLiteral transform from the Compose compiler.
@@ -158,8 +163,13 @@ public class ComposableInvalidationTrackTable @ComposeInvestigatorCompilerApi pu
 
   /** @suppress ComposeInvestigator compiler-only API */
   @ComposeInvestigatorCompilerApi
-  public fun callListeners(keyName: String, composable: AffectedComposable, type: ComposableInvalidationType) {
-    listeners[keyName]?.onInvalidate(composable, type)
+  public fun callListeners(
+    keyName: String,
+    callstack: List<String>,
+    composable: AffectedComposable,
+    type: ComposableInvalidationType,
+  ) {
+    listeners[keyName]?.onInvalidate(callstack, composable, type)
   }
 
   /** @suppress ComposeInvestigator compiler-only API */


### PR DESCRIPTION
Resolves #121.

This change breaks the previous API.