### PR TITLE
Correct group name and version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 
-GROUP=land.sungbin.composeinvestigator
-VERSION_NAME=internal-test
+GROUP=in.sungb.composeinvestigator
+VERSION_NAME=2.1.0-Beta1-1.0.0-beta01
 
 POM_DESCRIPTION=Trace the recomposition of a Composable with its cause without boilerplate code.
 POM_INCEPTION_YEAR=2024


### PR DESCRIPTION
I no longer own `sungbin.land`, so I renamed the group to `sungb.in`.